### PR TITLE
patch useradminstore to fetch the token automatically before requests

### DIFF
--- a/src/axios/getUserListRequest.js
+++ b/src/axios/getUserListRequest.js
@@ -1,6 +1,7 @@
 import axiosService from './axios'
 
 export const getUserListRequest = async (token) => {
+  console.log(`Creating requests to get user list with ${token}`)
   const response = await axiosService.get('/user/list', {
     headers: {
       'X-Auth-Token': token,

--- a/src/components/shared/HeaderLogo.vue
+++ b/src/components/shared/HeaderLogo.vue
@@ -3,7 +3,7 @@ import GenericLink from '../generics/GenericLink.vue';
 </script>
 
 <template>
-    <GenericLink href="/" containerClass="header__logo text-2xl" textContent="Furniro">
+    <GenericLink href="/admin" containerClass="header__logo text-2xl" textContent="Furniro">
         <img src="/logo_image.png" class="header__logo-image" alt="logo">
     </GenericLink>
 </template>

--- a/src/stores/adminUserStore.js
+++ b/src/stores/adminUserStore.js
@@ -3,24 +3,26 @@ import { defineStore } from 'pinia'
 import { getUserListRequest } from '@/axios/getUserListRequest'
 import { updateUserRequest } from '@/axios/updateUserRequest'
 import { deleteUserRequest } from '@/axios/deleteUserRequest'
+import {useUserStore} from './userStore'
 
 export const useAdminUserStore = defineStore('adminuser', () => {
     const users = ref({})
+    const userStore = useUserStore()
 
-    const getUsers = async (token) => {
-        const response = await getUserListRequest(token)
+    const getUsers = async () => {
+        const response = await getUserListRequest(userStore.token.key)
         if(response) users.value = response
     }
 
     //After Update and delete a webhook should be triggered that changes those values I think?
     //If no, then call getUser again
-    const updateUsers = async(token, modifiedUser) => {
-        const response = await updateUserRequest(JSON.stringify(modifiedUser), token)
+    const updateUsers = async(modifiedUser) => {
+        const response = await updateUserRequest(JSON.stringify(modifiedUser), userStore.token.key)
         return response
     }
 
-    const deleteUser = async(token, userId) =>{
-        const response = await deleteUserRequest(JSON.stringify([userId]), token)
+    const deleteUser = async(userId) =>{
+        const response = await deleteUserRequest(JSON.stringify([userId]), userStore.token.key)
         return response 
     }
 

--- a/src/views/AdminView.vue
+++ b/src/views/AdminView.vue
@@ -1,9 +1,15 @@
 <script setup>
+import {useAdminUserStore} from "../stores/adminUserStore"
+import { storeToRefs } from "pinia";
 
+const adminStore = useAdminUserStore()
+adminStore.getUsers()
+const users = storeToRefs(adminStore)
 </script>
 
 <template>
     <div>
+        <div>{{ users }}</div>
         <RouterView />
     </div>
 </template>


### PR DESCRIPTION
The following changes were introduced:
- Added userStore reference in adminUserStore
- Changed the logo to lead to admin route (temporarily)
- Showing in AdminView the users object
Issues:
- Cross Origin acting up when making admin requests:
![Screenshot 2024-04-12 080420](https://github.com/isd-soft/FE_Internship_2024/assets/53330933/4614482f-c510-44e6-a215-8cf8cc69b878)
- Could not verify if the storeToRefs function would be satisfying the needs of developers for this cause.